### PR TITLE
Add player list to rooms

### DIFF
--- a/GameServer/Caverns/IRoom.cs
+++ b/GameServer/Caverns/IRoom.cs
@@ -2,13 +2,21 @@
 {
     using GameServer.Commands;
     using GameServer.Messages;
+    using GameServer.Players;
     public interface IRoom
     {
         string Name { get; set; }
         public List<ISoundSensible> SoundSensibleObjects { get; }
+        public List<Player> Players { get; }
+
         public void AddAdjacentRoom(IRoom room);
         public IReadOnlyList<IRoom> GetConnectedRooms();
         public void ReceiveSound(Sound sound);
         public void ExecuteCommand(ICommand command);
+
+        public IReadOnlyList<Player> GetPlayers(); 
+        public void ReceivePlayer(Player player);
+        public void RemovePlayer(Player player);
+        public void WhisperPlayer(Player player);
     }
 }

--- a/GameServer/Caverns/Room.cs
+++ b/GameServer/Caverns/Room.cs
@@ -1,5 +1,6 @@
 ﻿using GameServer.Commands;
 using GameServer.Messages;
+using GameServer.Players;
 
 namespace GameServer.Caverns
 {
@@ -7,9 +8,12 @@ namespace GameServer.Caverns
     {
         public List<IRoom> _connectedRooms;
         public string Name { get; set; }
-
         private readonly List<ISoundSensible> _soundSensibleObjects = new List<ISoundSensible>();
-        public List<ISoundSensible> SoundSensibleObjects { get { return _soundSensibleObjects; } }
+
+        public List<ISoundSensible> SoundSensibleObjects => _soundSensibleObjects;
+
+        private readonly List<Player> _players = new List<Player>();
+        public List<Player> Players => _players;
 
         public Room(string name)
         {
@@ -36,6 +40,26 @@ namespace GameServer.Caverns
         public void ExecuteCommand(ICommand command)
         {
             command.Execute(this);
+        }
+
+        public IReadOnlyList<Player> GetPlayers()
+        {
+            return _players.AsReadOnly();
+        }
+
+        public void ReceivePlayer(Player player)
+        {
+            _players.Add(player);
+        }
+
+        public void RemovePlayer(Player player)
+        {
+            _players.Remove(player);
+        }
+
+        public void WhisperPlayer(Player player)
+        {
+            // TODO_BOGI forgot the use case of this function
         }
     }
 }

--- a/GameServer/Player/Player.cs
+++ b/GameServer/Player/Player.cs
@@ -1,4 +1,4 @@
-﻿namespace GameServer.Player
+﻿namespace GameServer.Players
 {
     public class Player
     {

--- a/GameServer/Player/PlayerStates/AliveActiveState.cs
+++ b/GameServer/Player/PlayerStates/AliveActiveState.cs
@@ -1,4 +1,4 @@
-﻿namespace GameServer.Player.PlayerStates
+﻿namespace GameServer.Players.PlayerStates
 {
     public class AliveActiveState : IState
     {

--- a/GameServer/Player/PlayerStates/IState.cs
+++ b/GameServer/Player/PlayerStates/IState.cs
@@ -1,4 +1,4 @@
-﻿namespace GameServer.Player.PlayerStates
+﻿namespace GameServer.Players.PlayerStates
 {
     public interface IState
     {

--- a/GameServerUnitTests/PlayerTests/PlayerStatesTests/AliveActiveStateTests.cs
+++ b/GameServerUnitTests/PlayerTests/PlayerStatesTests/AliveActiveStateTests.cs
@@ -1,4 +1,4 @@
-﻿using GameServer.Player.PlayerStates;
+﻿using GameServer.Players.PlayerStates;
 
 namespace GameServerUnitTests.PlayerTests.PlayerStatesTests
 {

--- a/GameServerUnitTests/PlayerTests/PlayerTests.cs
+++ b/GameServerUnitTests/PlayerTests/PlayerTests.cs
@@ -1,4 +1,4 @@
-﻿using GameServer.Player;
+﻿using GameServer.Players;
 
 namespace GameServerUnitTests.PlayerTests
 {

--- a/GameServerUnitTests/RoomTests/RoomTests.cs
+++ b/GameServerUnitTests/RoomTests/RoomTests.cs
@@ -1,42 +1,99 @@
-﻿
-using GameServer.Caverns;
+﻿using GameServer.Caverns;
+using GameServer.Players;
+using Moq;
 
 namespace GameServerUnitTests.RoomTests
 {
     [TestClass]
     public class RoomTests
     {
+        public IRoom? _room;
+
+        [TestInitialize]
+        public void RoomSetup()
+        {
+            _room = new Room("Room 1");
+        }
+
         [TestMethod]
         public void AddAdjacentRoom_ShouldLinkRoomToCurrentRoom()
         {
             // Arrange
-            IRoom room1 = new Room("Room 1");
+            if (_room == null)
+            {
+                Assert.Fail("Room is null");
+                return;
+            }
+
             IRoom room2 = new Room("Room 2");
 
             // Act
-            room1.AddAdjacentRoom(room2);
+            _room.AddAdjacentRoom(room2);
 
             // Assert
-            Assert.IsTrue(room1.GetConnectedRooms().Contains(room2));
+            Assert.IsTrue(_room.GetConnectedRooms().Contains(room2));
         }
 
         [TestMethod]
         public void GetConnectedRooms_ShouldReturnListOfConnectedRooms()
         {
             // Arrange
-            IRoom room1 = new Room("Room 1");
+            if (_room == null)
+            {
+                Assert.Fail("Room is null");
+                return;
+            }
+
             IRoom room2 = new Room("Room 2");
             IRoom room3 = new Room("Room 3");
-            room1.AddAdjacentRoom(room2);
-            room1.AddAdjacentRoom(room3);
+            _room.AddAdjacentRoom(room2);
+            _room.AddAdjacentRoom(room3);
 
             // Act
-            var connectedRooms = room1.GetConnectedRooms();
+            var connectedRooms = _room.GetConnectedRooms();
 
             // Assert
             Assert.IsTrue(connectedRooms.Contains(room2));
             Assert.IsTrue(connectedRooms.Contains(room3));
             Assert.AreEqual(2, connectedRooms.Count);
+        }
+
+        [TestMethod]
+        public void ReceivePlayer_ShouldAddPlayerToList()
+        {
+            // Arrange
+            if (_room == null)
+            {
+                Assert.Fail("Room is null");
+                return;
+            }
+
+            Mock<Player> player = new Mock<Player>();
+            //Act
+            _room.ReceivePlayer(player.Object);
+
+            //Assert
+            Assert.IsTrue(_room.GetPlayers().Contains(player.Object));
+        }
+
+        [TestMethod]
+        public void RemovePlayer_ShouldRemovePlayerFromList()
+        {
+            // Arrange
+            if (_room == null)
+            {
+                Assert.Fail("Room is null");
+                return;
+            }
+
+            Mock<Player> player = new Mock<Player>();
+            _room.ReceivePlayer(player.Object);
+            
+            //Act
+            _room.RemovePlayer(player.Object);
+
+            //Assert
+            Assert.IsFalse(_room.GetPlayers().Contains(player.Object));
         }
     }
 }


### PR DESCRIPTION
Add players to room. 
Add unit test.
Refactor some namespace naming to avoid conflicts and be able to use Player instead of Player.Player.
Forgot the use case of WhisperPlayer(Player p), so let it empty for the moment.